### PR TITLE
feat: make `username-in-use.html` screen template

### DIFF
--- a/templates/invalid-password.html
+++ b/templates/invalid-password.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Document</title>
+
+  <!-- This link, along with the scripts below, are 
+  needed for bootstrap and popper to work properly.-->
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css" rel="stylesheet"
+    integrity="sha384-GLhlTQ8iRABdZLl6O3oVMWSktQOp6b7In1Zl3/Jr59b6EGGoI1aFkw7cmDA6j6gD" crossorigin="anonymous">
+
+</head>
+
+
+<body>
+
+  <div class="container-fluid">
+    <div class="row">
+      <div class="display-2" style="text-align:center;">
+        Invalid password
+
+        <!-- This svg is the icon used for the symbol image being shown.
+        This svg is treated as inline with the text.-->
+        <svg xmlns="http://www.w3.org/2000/svg" width="105px" height="105px" fill="currentColor" class="bi bi-exclamation-square d-block mx-auto my-3"
+          viewBox="0 0 16 16">
+          <path
+            d="M14 1a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1h12zM2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2H2z" />
+          <path
+            d="M7.002 11a1 1 0 1 1 2 0 1 1 0 0 1-2 0zM7.1 4.995a.905.905 0 1 1 1.8 0l-.35 3.507a.552.552 0 0 1-1.1 0L7.1 4.995z" />
+        </svg>
+      </div>
+    </div>
+  </div>
+
+
+  <!-- This script is used for bootstrap and popper 
+  without having to download all the files for both-->
+  <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.6/dist/umd/popper.min.js"
+    integrity="sha384-oBqDVmMz9ATKxIep9tiCxS/Z9fNfEXiDAYTujMAeBAsjFuCZSmKbSSUnQlmh/jp3"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.min.js"
+    integrity="sha384-mQ93GR66B00ZXjt0YO5KlohRA5SY2XofN4zfuZxLkoj1gXtW8ANNCe9d5Y3eG5eD"
+    crossorigin="anonymous"></script>
+
+</body>
+
+</html>

--- a/templates/invalid-username.html
+++ b/templates/invalid-username.html
@@ -24,7 +24,6 @@
 
         <!-- This svg is the icon used for the symbol image being shown.
         This svg is treated as inline with the text.-->
-
         <svg xmlns="http://www.w3.org/2000/svg" width="105px" height="105px" fill="currentColor" class="bi bi-exclamation-square d-block mx-auto my-3"
           viewBox="0 0 16 16">
           <path

--- a/templates/invalid-username.html
+++ b/templates/invalid-username.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Document</title>
+
+  <!-- This link, along with the scripts below, are 
+  needed for bootstrap and popper to work properly.-->
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css" rel="stylesheet"
+    integrity="sha384-GLhlTQ8iRABdZLl6O3oVMWSktQOp6b7In1Zl3/Jr59b6EGGoI1aFkw7cmDA6j6gD" crossorigin="anonymous">
+
+</head>
+
+
+<body>
+
+  <div class="container-fluid">
+    <div class="row">
+      <div class="display-2" style="text-align:center;">
+        Invalid username
+
+        <!-- This svg is the icon used for the symbol image being shown.
+        This svg is treated as inline with the text.-->
+
+        <svg xmlns="http://www.w3.org/2000/svg" width="105px" height="105px" fill="currentColor" class="bi bi-exclamation-square d-block mx-auto my-3"
+          viewBox="0 0 16 16">
+          <path
+            d="M14 1a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1h12zM2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2H2z" />
+          <path
+            d="M7.002 11a1 1 0 1 1 2 0 1 1 0 0 1-2 0zM7.1 4.995a.905.905 0 1 1 1.8 0l-.35 3.507a.552.552 0 0 1-1.1 0L7.1 4.995z" />
+        </svg>
+      </div>
+    </div>
+  </div>
+
+
+  <!-- This script is used for bootstrap and popper 
+  without having to download all the files for both-->
+  <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.6/dist/umd/popper.min.js"
+    integrity="sha384-oBqDVmMz9ATKxIep9tiCxS/Z9fNfEXiDAYTujMAeBAsjFuCZSmKbSSUnQlmh/jp3"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.min.js"
+    integrity="sha384-mQ93GR66B00ZXjt0YO5KlohRA5SY2XofN4zfuZxLkoj1gXtW8ANNCe9d5Y3eG5eD"
+    crossorigin="anonymous"></script>
+
+</body>
+
+</html>

--- a/templates/username-in-use.html
+++ b/templates/username-in-use.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Document</title>
+
+  <!-- This link, along with the scripts below, are 
+  needed for bootstrap and popper to work properly.-->
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css" rel="stylesheet"
+    integrity="sha384-GLhlTQ8iRABdZLl6O3oVMWSktQOp6b7In1Zl3/Jr59b6EGGoI1aFkw7cmDA6j6gD" crossorigin="anonymous">
+
+</head>
+
+
+<body>
+
+  <div class="container-fluid">
+    <div class="row">
+      <div class="display-2" style="text-align:center;">
+        <div>Username already in use</div>
+
+        <!-- This svg is the icon used for the symbol image being shown.
+        This svg is treated as inline with the text.-->
+        <svg xmlns="http://www.w3.org/2000/svg" width="128px" height="128px" fill="currentColor"
+          class="bi bi-person-exclamation d-block mx-auto" viewBox="0 0 16 16">
+          <path
+            d="M11 5a3 3 0 1 1-6 0 3 3 0 0 1 6 0ZM8 7a2 2 0 1 0 0-4 2 2 0 0 0 0 4Zm.256 7a4.474 4.474 0 0 1-.229-1.004H3c.001-.246.154-.986.832-1.664C4.484 10.68 5.711 10 8 10c.26 0 .507.009.74.025.226-.341.496-.65.804-.918C9.077 9.038 8.564 9 8 9c-5 0-6 3-6 4s1 1 1 1h5.256Z" />
+          <path
+            d="M16 12.5a3.5 3.5 0 1 1-7 0 3.5 3.5 0 0 1 7 0Zm-3.5-2a.5.5 0 0 0-.5.5v1.5a.5.5 0 0 0 1 0V11a.5.5 0 0 0-.5-.5Zm0 4a.5.5 0 1 0 0-1 .5.5 0 0 0 0 1Z" />
+        </svg>
+      </div>
+    </div>
+  </div>
+
+
+  <!-- This script is used for bootstrap and popper 
+  without having to download all the files for both-->
+  <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.6/dist/umd/popper.min.js"
+    integrity="sha384-oBqDVmMz9ATKxIep9tiCxS/Z9fNfEXiDAYTujMAeBAsjFuCZSmKbSSUnQlmh/jp3"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.min.js"
+    integrity="sha384-mQ93GR66B00ZXjt0YO5KlohRA5SY2XofN4zfuZxLkoj1gXtW8ANNCe9d5Y3eG5eD"
+    crossorigin="anonymous"></script>
+
+</body>
+
+</html>

--- a/templates/username-in-use.html
+++ b/templates/username-in-use.html
@@ -20,7 +20,7 @@
   <div class="container-fluid">
     <div class="row">
       <div class="display-2" style="text-align:center;">
-        <div>Username already in use</div>
+        Username already in use
 
         <!-- This svg is the icon used for the symbol image being shown.
         This svg is treated as inline with the text.-->


### PR DESCRIPTION
This PR implements the `username-in-use`, `invalid-username`, and `invalid-password` barebones screen templates for the website. That is, the templates are not connected to each other yet in any imaginable way, and are just there as prototypes for the site that is soon to come. 

The images, as well as the implementation of Bootstrap and Popper, were both referenced and taken online to allow for the end-user to not have to download all the files contained within them (with some even going unused). The images were taken from [Bootstrap Icons](https://icons.getbootstrap.com) while the cached versions of Bootstrap and Popper were taken from [jsDelivr](https://www.jsdelivr.com).